### PR TITLE
Imas interface

### DIFF
--- a/src/TorJ.jl
+++ b/src/TorJ.jl
@@ -4,13 +4,13 @@ import Optim
 import Interpolations: cubic_spline_interpolation, Line, Extrapolation, gradient
 import ForwardDiff
 import LinearAlgebra
-import IMAS
-using DifferentialEquations
-using NLsolve
-using Roots
+using IMAS
+import DifferentialEquations
+import NLsolve
+import Roots
 using SpecialFunctions: besselj
-using FastGaussQuadrature
-using Dagger
+import FastGaussQuadrature
+import Dagger
 import Dierckx
 
 # Module-level constants (equivalent to Fortran parameters)

--- a/src/absorption.jl
+++ b/src/absorption.jl
@@ -1,7 +1,7 @@
 function abs_Al_init(N_absz::Int)
     # Get Gauss-Legendre quadrature points and weights on [-1, 1]
     global _int_weights, _int_absz
-    _int_absz, _int_weights = gausslegendre(N_absz)
+    _int_absz, _int_weights = FastGaussQuadrature.gausslegendre(N_absz)
     _int_absz = Vector{Float64}(_int_absz)
     _int_weights = Vector{Float64}(_int_weights)
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,4 +1,24 @@
 
+
+
+"""
+    Base.@kwdef struct TorJParams
+
+Provides a structure for code parameters. All values have defaults.
+    - s_max: # Stopping condition for the raytracer if there is insufficient absorption [m]. Defaults to 1 m
+    - N_rings: Number of radial rings of rays in the beam. Defaults to 3
+    - min_azimuthal_points: Number of poloidal rays in the innermost rings. The outer rings will have more than this. Defaults to 5
+"""
+
+Base.@kwdef struct TorJParams
+    s_max:: Float64 = 1.0 
+    N_rings:: Int64 = 3 
+    min_azimuthal_points:: Int64 = 5
+    N_dP_dV::Int64 = 1000
+end
+
+
+
 """
     on_grid(plasma::T, p0::T) where {T<:Real}
 
@@ -26,7 +46,7 @@ function first_point(plasma::Plasma, p0::AbstractVector{T}, N0::Vector{T}) where
     end
     g(t) = evaluate(plasma.psi_norm_spline, p_plasma .+ t .* N0) - plasma.psi_prof_max
     # TODO find better estimate for upper limit of distance between first point on grid and plasma.psi_prof_max
-    p_plasma += find_zero(g, (0.0, 0.5), Bisection(); xtol=1e-6).* N0
+    p_plasma += Roots.find_zero(g, (0.0, 0.5), Roots.Bisection(); xtol=1e-6).* N0
     psi_ref = evaluate(plasma.psi_norm_spline, p_plasma)
     # If root finding failed horribly we catch it here
     @assert abs(psi_ref - plasma.psi_prof_max) < 1.e-6
@@ -68,7 +88,7 @@ function vacuum_plasma_refraction(plasma::Plasma, p_plasma::AbstractVector{T},
     n[3] = dpsi_dz
     n = n ./ LinearAlgebra.norm(n)
     x0 = N0 .* N_est
-    solver_results = nlsolve((F,N) -> refraction_equations!(F, N, X, Y, N0 / LinearAlgebra.norm(N0), n, b, mode), 
+    solver_results = NLsolve.nlsolve((F,N) -> refraction_equations!(F, N, X, Y, N0 / LinearAlgebra.norm(N0), n, b, mode), 
                              x0, autodiff = :forward; ftol = 1.e-12)
     return solver_results.zero
 end
@@ -152,13 +172,14 @@ function make_ray(plasma::Plasma, x0::AbstractVector{<:T}, N_vacuum::AbstractVec
     # Add the first two points
     u = vec([vec(x0), p_plasma])
     for i in 1:N_steps
-        prob = ODEProblem((du, u, p, s) -> sys!(du, u, p, s, plasma, 2.0 * pi *f, mode), u0, 
-                          (Float64(i-1)*s_step + s0, Float64(i)*s_step + s0), OwrenZen3(); 
-                          dtmax=1.e-4, abstol=1.e-6, reltol=1.e-6)
+        prob = DifferentialEquations.ODEProblem((du, u, p, s) -> sys!(du, u, p, s, plasma, 2.0 * pi *f, mode), u0, 
+                                                (Float64(i-1)*s_step + s0, Float64(i)*s_step + s0), 
+                                                DifferentialEquations.OwrenZen3(); 
+                                                dtmax=1.e-4, abstol=1.e-6, reltol=1.e-6)
         # Ensure that the power does not oscillate around 0.0
         condition(u, t, integrator) = u[7] < 0
-        cb = ContinuousCallback(condition, affect!)
-        sol = solve(prob, callback=cb)
+        cb = DifferentialEquations.ContinuousCallback(condition, affect!)
+        sol = DifferentialEquations.solve(prob, callback=cb)
         u0 = sol.u[end]
         append!(s, sol.t[2:end])
         # Extract position vectors (first 3 components) from each solution step
@@ -178,6 +199,90 @@ function make_ray(plasma::Plasma, x0::AbstractVector{<:T}, N_vacuum::AbstractVec
     # Finally add the offset from the vacuum step
     dP_dV_ray, deposited_power = power_deposition_profile(plasma, s, u, dP_ds, psi_dP_dV)
     return s, u, P_beam, dP_dV_ray, deposited_power
+end
+
+"""
+    spawn_beam_tasks(plasma, r, phi, z, steering_angle_tor, steering_angle_pol, spot_size, inverse_curvature_radius, f, mode, s_max, psi_dP_dV; kwargs...)
+
+Spawn Dagger tasks for multiple rays forming a beam.
+
+# Arguments
+- `plasma`: Plasma configuration containing density, temperature, and magnetic field
+- `r`: Radial distance of beam center (meters)
+- `phi`: Toroidal angle of beam center (radians)
+- `z`: Vertical position of beam center (meters)
+- `steering_angle_tor`: Toroidal steering angle (radians)
+- `steering_angle_pol`: Poloidal steering angle (radians)
+- `spot_size`: Beam spot size parameter (meters)
+- `inverse_curvature_radius`: Inverse radius of curvature (1/meters)
+- `f`: Wave frequency (Hz)
+- `mode`: Polarization mode (+1 for X-mode, -1 for O-mode)
+- `s_max`: Maximum integration distance (meters)
+- `psi_dP_dV`: Psi axis for power deposition profile
+
+# Returns
+- `ray_tasks`: Vector of Dagger task objects
+- `ray_weights`: Ray weights for beam integration
+"""
+function spawn_beam_tasks(plasma::Plasma, r::T, phi::T, z::T, steering_angle_tor::T, steering_angle_pol::T, spot_size::T, 
+                          inverse_curvature_radius::T, f::T, mode::Integer, s_max::Float64, psi_dP_dV::Vector{T}; kwargs...) where {T<:Real}
+    N0 = collect(IMAS.pol_tor_angles_2_vector(steering_angle_pol, steering_angle_tor))
+    x0 = zeros(Float64,3)
+    x0[1] = r * cos(phi)
+    x0[2] = r * sin(phi)
+    x0[3] = z
+    ray_positions, ray_directions, ray_weights = TorJ.launch_peripheral_rays(
+        x0, N0, spot_size, inverse_curvature_radius, f; kwargs...)
+    ray_tasks = []
+    Dagger.spawn_bulk() do
+        for i in eachindex(ray_weights)
+            push!(ray_tasks, Dagger.@spawn make_ray(plasma, ray_positions[i,:], ray_directions[i,:], 
+                                                    f, mode, s_max, psi_dP_dV) )
+        end
+    end
+    return ray_tasks, ray_weights
+end
+
+"""
+    fetch_beam_results(ray_tasks, ray_weights, psi_dP_dV)
+
+Fetch and process results from spawned beam tasks.
+
+# Arguments
+- `ray_tasks`: Vector of Dagger task objects
+- `ray_weights`: Ray weights for beam integration
+- `psi_dP_dV`: Psi axis for power deposition profile
+
+# Returns
+- `arc_lengths`: Vector of arclength arrays (one per ray)
+- `trajectories`: Vector of trajectory arrays (one per ray)  
+- `ray_powers`: Vector of beam power arrays (one per ray)
+- `dP_dV`: Integrated power deposition profile
+- `deposited_power`: Total deposited power
+- `ray_weights`: Ray weights for beam integration
+"""
+function fetch_beam_results(ray_tasks, ray_weights, psi_dP_dV)
+    ray_results = []
+     # Collect results preserving order (ensures correspondence with ray_weights)
+    for i in eachindex(ray_tasks)
+        push!(ray_results, Dagger.fetch(ray_tasks[i]))
+    end
+    # Separate the three return values
+    arc_lengths = [result[1] for result in ray_results]
+    trajectories = [result[2] for result in ray_results]
+    ray_powers = [result[3] for result in ray_results]
+    dP_dV_ray  = [result[4] for result in ray_results]
+    deposited_power_ray  = [result[5] for result in ray_results]
+    
+    dP_dV = zeros(Float64, length(psi_dP_dV))
+    # From the power deposition profile
+    deposited_power = 0.0
+    # From the rays directly
+    for i_ray in eachindex(ray_weights)
+        dP_dV .+= dP_dV_ray[i_ray] * ray_weights[i_ray]
+        deposited_power += deposited_power_ray[i_ray] * ray_weights[i_ray]
+    end
+    return arc_lengths, trajectories, ray_powers, dP_dV, deposited_power, ray_weights 
 end
 
 """
@@ -208,35 +313,108 @@ Launch multiple rays forming a beam and compute their trajectories with absorpti
 """
 function make_beam(plasma::Plasma, r::T, phi::T, z::T, steering_angle_tor::T, steering_angle_pol::T, spot_size::T, 
                    inverse_curvature_radius::T, f::T, mode::Integer, s_max::Float64, psi_dP_dV::Vector{T}; kwargs...) where {T<:Real}
-    N0 = collect(IMAS.pol_tor_angles_2_vector(steering_angle_pol, steering_angle_tor))
-    x0 = zeros(Float64,3)
-    x0[1] = r * cos(phi)
-    x0[2] = r * sin(phi)
-    x0[3] = z
-    ray_positions, ray_directions, ray_weights = TorJ.launch_peripheral_rays(
-        x0, N0, spot_size, inverse_curvature_radius, f; kwargs...)
-    
-    ray_tasks = [Dagger.@spawn make_ray(plasma, ray_positions[i,:], ray_directions[i,:], 
-                                        f, mode, s_max, psi_dP_dV) 
-                 for i in 1:length(ray_weights)]
-    
-    # Collect results preserving order (ensures correspondence with ray_weights)
-    ray_results = [fetch(ray_tasks[i]) for i in 1:length(ray_tasks)]
-    
-    # Separate the three return values
-    arc_lengths = [result[1] for result in ray_results]
-    trajectories = [result[2] for result in ray_results]
-    ray_powers = [result[3] for result in ray_results]
-    dP_dV_ray  = [result[4] for result in ray_results]
-    deposited_power_ray  = [result[5] for result in ray_results]
-    
-    dP_dV = zeros(Float64, length(psi_dP_dV))
-    # From the power deposition profile
-    deposited_power = 0.0
-    # From the rays directly
-    for i_ray in eachindex(ray_weights)
-        dP_dV .+= dP_dV_ray[i_ray] * ray_weights[i_ray]
-        deposited_power += deposited_power_ray[i_ray] * ray_weights[i_ray]
+    ray_tasks, ray_weights = spawn_beam_tasks(plasma, r, phi, z, steering_angle_tor, steering_angle_pol, spot_size, 
+                                              inverse_curvature_radius, f, mode, s_max, psi_dP_dV; kwargs...)
+    return fetch_beam_results(ray_tasks, ray_weights, psi_dP_dV)
+end
+
+function process_ids!(dd:: IMAS.dd; torj_params::TorJParams = TorJParams())
+    nbeam = length(dd.ec_launchers.beam)
+    if nbeam < 1
+        return nbeam
     end
-    return arc_lengths, trajectories, ray_powers, dP_dV, deposited_power, ray_weights 
+
+    plasma = Plasma(dd)
+    
+    psi_norm_dP_dV = Vector(LinRange(0.0, 1.0, torj_params.N_dP_dV))
+    beam_tasks = []
+    wait(Dagger.spawn_sequential() do
+        for ibeam in 1:nbeam
+            beam = dd.ec_launchers.beam[ibeam]
+            f = IMAS.@ddtime(beam.frequency.data)
+
+            # Elliptical beam parameters (not supported yet) -> circular beam
+            inverse_curvature_radius = 0.5*(beam.phase.curvature[1, 1] + beam.phase.curvature[2, 1])
+            spot_size = 0.5*(beam.spot.size[1, 1] + beam.spot.size[2, 1])
+            
+            # Sign convention opposite to IMAS
+            mode = -beam.mode
+            push!(beam_tasks, Dagger.@spawn make_beam(plasma, 
+                    beam.launching_position.r[1], beam.launching_position.phi[1], 
+                    beam.launching_position.z[1], 
+                    IMAS.@ddtime(dd.ec_launchers.beam[ibeam].steering_angle_tor), 
+                    IMAS.@ddtime(dd.ec_launchers.beam[ibeam].steering_angle_pol), 
+                    spot_size, inverse_curvature_radius, f, mode, 
+                    torj_params.s_max, psi_norm_dP_dV; N_rings = torj_params.N_rings, 
+                    min_azimuthal_points = torj_params.min_azimuthal_points))
+            
+        end
+    end)
+     # Collect results preserving order (ensures correspondence with ray_weights)
+    beam_results = [Dagger.fetch(beam_tasks[i]) for i in eachindex(beam_tasks)]
+
+    # Prepare the output
+    rho_tor_norm_interpolator = IMAS.interp1d(eqt1d.psi, eqt1d.rho_tor_norm)
+    resize!(dd.waves.coherent_wave, nbeam)
+    rho_tor_norm_dP_dV = rho_tor_norm_interpolator(psi_norm_dP_dV)
+
+    for i_beam in eachindex(beam_results)
+        arc_lengths, trajectories, ray_powers, dP_dV, deposited_power, ray_weights = beam_results[i_beam]
+        beam = dd.ec_launchers.beam[ibeam]
+        ps_beam = dd.pulse_schedule.ec.beam[ibeam]
+        power_launched = IMAS.@ddtime(ps_beam.power_launched.reference)
+
+        wv = dd.waves.coherent_wave[ibeam]
+        wv.identifier.antenna_name = beam.name
+        wv.identifier.type.description = "TorJ"
+        wv.identifier.type.name = "EC"
+        wv.identifier.type.index = 1
+        wv.wave_solver_type.index = 1 # BEAM/RAY TRACING
+
+        wvg = resize!(wv.global_quantities) # global_time
+        wvg.frequency = IMAS.@ddtime(beam.frequency.data)
+        # torj never sees the launched power so we handle it here
+        wvg.electrons.power_thermal = deposited_power * power_launched
+        wvg.power = deposited_power * power_launched
+        wvg.current_tor = undef
+
+        wv1d = resize!(wv.profiles_1d) # global_time
+        wv.profiles_1d[1].time = IMAS.@ddtime(dd.equilibrium.time)
+        wv1d.grid.rho_tor_norm = rho_tor_norm_dP_dV
+        wv1d.grid.psi = psi_norm_dP_dV
+        wv1d.power_density = dP_dV .* power_launched
+
+        source = resize!(dd.core_sources.source, :ec, "identifier.name" => beam.name; wipe=false)
+        IMAS.new_source(
+            source,
+            source.identifier.index,
+            beam.name,
+            wv1d.grid.rho_tor_norm,
+            wv1d.grid.volume,
+            wv1d.grid.area;
+            electrons_energy=wv1d.power_density)
+
+        # LOOP OVER RAYS
+        wvb = resize!(wv.beam_tracing) # global_time
+        resize!(wvb.beam, torbeam_params.n_ray) # Five beams/per gyrotron
+        iend[] = min(npointsout[ibeam], ntraj)
+        if power_launched > 0.0
+            for i_ray in eachindex(ray_weights)
+                wvb.beam[i_ray].power_initial = ray_weights[i_ray] * power_launched
+                s = arc_lengths[i_ray]
+                x = [point[1] for point in trajectories[i_ray]]
+                y = [point[2] for point in trajectories[i_ray]]
+                z = [point[z] for point in trajectories[i_ray]]
+                r = hypot(x, y)
+                wvb.beam[i_ray].length = s
+                wvb.beam[i_ray].position.r = r
+                wvb.beam[i_ray].position.phi = phi
+                wvb.beam[i_ray].position.z = z
+            end
+        end
+
+    end # LOOP OVER BEAMS (LAUNCHERS)
+
+    IMAS.@ddtime(dd.waves.code.output_flag = 0) # NO ERROR
+    return dd
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -319,7 +319,7 @@ function make_beam(plasma::Plasma, r::T, phi::T, z::T, steering_angle_tor::T, st
     return fetch_beam_results(ray_tasks, ray_weights, psi_dP_dV)
 end
 
-function process_ids!(dd:: IMAS.dd; torj_params::TorJParams = TorJParams())
+function process_ids!(dd::IMAS.dd; torj_params::TorJParams = TorJParams())
     nbeam = length(dd.ec_launchers.beam)
     if nbeam < 1
         return nbeam
@@ -415,6 +415,7 @@ function process_ids!(dd:: IMAS.dd; torj_params::TorJParams = TorJParams())
                 wvb.beam[i_ray].position.r = r
                 wvb.beam[i_ray].position.phi = atan.(y,x)
                 wvb.beam[i_ray].position.z = z
+                wvb.beam[i_ray].electrons.power = (1.0 .- ray_powers[i_ray]) .* (ray_weights[i_ray] * power_launched)
             end
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ else
     include("tests/test_absorption.jl")
     include("tests/test_launch_weights.jl")
     include("tests/test_make_beam.jl")
+    include("tests/test_process_ids.jl")
 end
 
 

--- a/test/tests/setup.jl
+++ b/test/tests/setup.jl
@@ -31,7 +31,7 @@ if !@isdefined(TEST_DATA_LOADED) || FORCE_RELOAD_TEST_DATA
     dd = IMAS.json2imas(artifact_path *"/data/sample_L_mode_peaked.json"; error_on_missing_coordinates=false)
     dd.global_time = 2.0
 
-    plasma = TorJ.Plasma(dd);
+    plasma = TorJ.Plasma(dd)
     # For comparing against TORBEAM we want less dispersion
     plasma_low_density = TorJ.Plasma(dd; ne_scale=0.3);
 
@@ -61,6 +61,7 @@ if !@isdefined(TEST_DATA_LOADED) || FORCE_RELOAD_TEST_DATA
 
     # Fill in ec_launchers and pulse_schedule
     IMAS.resize!(dd.ec_launchers.beam, 2)
+    dd.ec_launchers.beam[1].name = "Test gyrotron 1"
     dd.ec_launchers.beam[1].time = ones(Float64, 1) .* 2.0
     dd.ec_launchers.beam[1].frequency.data = ones(Float64, 1) .* f
     dd.ec_launchers.beam[1].frequency.time = ones(Float64, 1) .* 2.0
@@ -80,6 +81,7 @@ if !@isdefined(TEST_DATA_LOADED) || FORCE_RELOAD_TEST_DATA
 
     dd.ec_launchers.beam[2] = deepcopy(dd.ec_launchers.beam[1])
     dd.ec_launchers.beam[2].frequency.data[:] .= f_abs_test
+    dd.ec_launchers.beam[1].name = "Test gyrotron 2"
 
     IMAS.resize!(dd.pulse_schedule.ec.beam, 2)
     dd.pulse_schedule.ec.time = ones(Float64, 1) .* 2.0

--- a/test/tests/setup.jl
+++ b/test/tests/setup.jl
@@ -81,7 +81,7 @@ if !@isdefined(TEST_DATA_LOADED) || FORCE_RELOAD_TEST_DATA
 
     dd.ec_launchers.beam[2] = deepcopy(dd.ec_launchers.beam[1])
     dd.ec_launchers.beam[2].frequency.data[:] .= f_abs_test
-    dd.ec_launchers.beam[1].name = "Test gyrotron 2"
+    dd.ec_launchers.beam[2].name = "Test gyrotron 2"
 
     IMAS.resize!(dd.pulse_schedule.ec.beam, 2)
     dd.pulse_schedule.ec.time = ones(Float64, 1) .* 2.0

--- a/test/tests/test_process_ids.jl
+++ b/test/tests/test_process_ids.jl
@@ -1,0 +1,6 @@
+include("setup.jl")
+# Simple functionality test.
+@testset "Raytrace test" begin
+    println("Using $(Threads.nthreads()) threads")
+    TorJ.process_ids!(dd)
+end


### PR DESCRIPTION
This allows TorJ to process `dd` similarly to the Torbeam interface with the new `process_ids!` method that takes a `dd` instance as an input. TorJ is heavily parallelized and can use 100+ cores if sufficient beams exist.